### PR TITLE
Fix typo in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ local_js:
   - //cdnjs.cloudflare.com/ajax/libs/mustache.js/0.8.1/mustache.min.js
   - /js/purl.js
   - /js/try.js
-  - /js/snufflupadata.js
+  - /js/snuffleupadata.js
   - /js/github.js
 
 gems:


### PR DESCRIPTION
Image of JS error ` GET http://dev.socrata.com/js/snufflupadata.js (index):1705`:
https://www.evernote.com/shard/s1/sh/0aa0443a-4b4a-4454-8677-a81f18fc5264/ba64d56fc80f7c281350ded9f3996186/deep/0/Developer-Tools---http---dev.socrata.com-foundry--and-Editing-dev.socrata.com-_config.yml-at-gh-pages---socrata-dev.socrata.com-and-Slack.png