### PR TITLE
Corrected reference to 311 service requests for vacant/abandoned buildings

### DIFF
--- a/docs/functions/within_polygon.md
+++ b/docs/functions/within_polygon.md
@@ -26,6 +26,6 @@ The `within_polygon(...)` function is used in the `$where` parameter filter for 
   <p><em>Heads up!</em> Contrary to the normal convention of "latitude, longitude" ordering in the <code>coordinates</code> property, Well-known text orders the coordinates as "longitude, latitude" (X coordinate, Y coordinate), as other GIS coordiate systems are encoded.</p>
 </div>
 
-For example, to query for all of the Chicago Crimes within that polygon:
+For example, to query for all of the Chicago 311 service requests for vacant and abandoned buildings within that polygon:
 
 {% include tryit.html domain='data.cityofchicago.org' path='/resource/yama-9had.json' args="$where=within_polygon(location, 'MULTIPOLYGON (((-87.637714 41.887275, -87.613681 41.886892, -87.625526 41.871555, -87.637714 41.887275)))')" %}


### PR DESCRIPTION
The Chicago crimes data set was identified but the URI pointed to the 311 services requests for vacant and abandoned buildings. This corrects the error by changing the reference in the text (i.e., did not change the URI at all).