### PR TITLE
Update queries.md to fix broken link.

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -20,7 +20,7 @@ as a URL parameter or as a SoQL statement. If a parameter is not specified, then
 | [`$select`](#the-select-parameter) | The set of columns to be returned                                                                   | All columns, equivalent to `$select=*`                     |
 | [`$where`](#the-where-parameter)   | Filters the rows to be returned                                                                     | No filter, and returning a max of `$limit` values          |
 | [`$order`](#the-order-parameter)   | Specifies the order of results                                                                      | Unspecified order, but it will be consistent across paging |
-| [`$group`](#the-group-parameter)   | Column to group results on, similar to [SQL Grouping](http://www.w3schools.com/sql/sql-groupby.asp) | No grouping                                                |
+| [`$group`](#the-group-parameter)   | Column to group results on, similar to [SQL Grouping](http://www.w3schools.com/sql/sql_groupby.asp) | No grouping                                                |
 | [`$limit`](#the-limit-parameter)   | Maximum number of results to return                                                                 | 1000 (with a maximum of 50,000)                            |
 | [`$offset`](#the-offset-parameter) | Offset count into the results to start at, used for paging                                          | 0                                                          |
 | [`$q`](#search-with-q)             | Performs a full text search for a value.                                                            | No search                                                  |


### PR DESCRIPTION
The link to the w3schools article on SQL Group By was broken (used a dash instead of an underscore).