### PR TITLE
Added wiki link as documentation for PhpSoda

### DIFF
--- a/libraries/SodaPhp.md
+++ b/libraries/SodaPhp.md
@@ -7,7 +7,7 @@ audience: all
 language: PHP
 
 external_url: https://github.com/allejo/PhpSoda
-docs_url: https://github.com/allejo/PhpSoda/blob/master/README.md
+docs_url: https://github.com/allejo/PhpSoda/wiki
 bugs_url: https://github.com/allejo/PhpSoda/issues
 
 github_user: allejo


### PR DESCRIPTION
For the documentation link, the wiki provides better documentation than the README so I've updated the URL