### PR TITLE
Fixes #288: Escaping quotes and double quotes so that they don't get

### DIFF
--- a/_includes/tryit.html
+++ b/_includes/tryit.html
@@ -1,2 +1,2 @@
 {% capture full_url %}https://{{ include.domain }}{{ include.path }}?{{ include.args }}{% endcapture %}
-<a class="tryit" href="{{full_url}}">{{full_url}}</a>
+<a class="tryit" href="{{full_url}}">{{ full_url | replace: "'", "&#39;" | replace: "\"", "&quot;" }}</a>


### PR DESCRIPTION
replaced by fancy-ass ones