### PR TITLE
Fixes #364 to resize dropdown menu height to browser height.

### DIFF
--- a/css/local.sass
+++ b/css/local.sass
@@ -42,6 +42,9 @@ iframe.live-docs
     &:not(:first-child)
       border-top: 1px solid #f1f1f1
   .dropdown-menu
+    overflow-x: auto
+    height: auto
+    max-height: 85vh
     -webkit-user-select: none
     -moz-user-select: none
     -ms-user-select: none


### PR DESCRIPTION
Added styling changes to the dropdown menu so it adjusts accordingly to the browser height. This is a proposed fix for Issue #364.