### PR TITLE
Fixes #417: Redirect /foundry to homepage

### DIFF
--- a/js/foundry-redirect.js
+++ b/js/foundry-redirect.js
@@ -1,3 +1,7 @@
 require(["jquery", "jquery.redirect"], function($, Redirect) {
-  $.redirect("/foundry" + window.location.hash.replace("#", ""));
+  if(window.hash != null) {
+    $.redirect("/foundry" + window.location.hash.replace("#", ""));
+  } else {
+    $.redirect("/");
+  }
 });


### PR DESCRIPTION
If we don't have a hash when we hit /foundry, we don't actually have
a Foundry URL. Redirect at least to the homepage.