### PR TITLE
Removing extra geoJSON in Line docs

### DIFF
--- a/docs/datatypes/line.md
+++ b/docs/datatypes/line.md
@@ -33,13 +33,10 @@ The `Line` datatype represents a path on the Earth as a sequence of WGS84 Latitu
 
 {% highlight javascript %}
 {
-  "type": "Feature",
-  "geometry": {
-    "type": "LineString",
-    "coordinates": [
-      [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
-    ]
-  }
+  "type": "LineString",
+  "coordinates": [
+    [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+  ]
 }
 {% endhighlight %}
 


### PR DESCRIPTION
related to #559, this normalizes docs for Line to the docs for other geometry column types ([Point](https://dev.socrata.com/docs/datatypes/point.html), [MultiLine](https://dev.socrata.com/docs/datatypes/multiline.html), etc.) by removing the "geoJSON envelope". 