### PR TITLE
Linking to Discovery API

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -103,6 +103,7 @@
   {% comment %} <li><a href="/docs/datatypes/converting.html">Conversions</a></li> {% endcomment %}
 
   <li class="nav-header dropdown-header">Other APIs</li>
+  <li><a href="http://docs.socratadiscovery.apiary.io/">Discovery</a></li>
   <li><a href="/odata/">OData</a></li>
   <li><a href="http://docs.openperformance.apiary.io/">Open Performance</a></li>
 


### PR DESCRIPTION
This was mentioned in the Q3 webinar today, and the presenters directed viewers to the dev site; but I didn't see the link anywhere. 