### PR TITLE
Fixed functions using Chicago salary data examples

### DIFF
--- a/docs/functions/count.md
+++ b/docs/functions/count.md
@@ -38,8 +38,8 @@ parents:
 
 The `count(...)` function is most commonly used in `$select` aggregations to return the count of a set of values. For example, to fetch the total number of employees of the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=count(salary)" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=count(annual_salary)" %}
 
 It can also be used in `$group` aggregations, like this one to get the count of employees by job type:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=position_title,count(salary)&$group=position_title" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=position_title,count(annual_salary)&$group=position_title" %}

--- a/docs/functions/lower.md
+++ b/docs/functions/lower.md
@@ -25,4 +25,4 @@ parents:
 
 The `lower(...)` function is used within the `$select` or `$where` parameters to lower-case a [Text](/docs/datatypes/text.html) value. For example, you could use it within the `$select` statement to lower-case names from the Chicago salaries dataset:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=lower(name), salary" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=lower(name), annual_salary" %}

--- a/docs/functions/max.md
+++ b/docs/functions/max.md
@@ -33,7 +33,7 @@ parents:
 
 The `max(...)` function is most commonly used in `$select` aggregations to return the maximum of a set of numeric values ([Numbers](/docs/datatypes/number.html), [Doubles](/docs/datatypes/double.html), or [Moneys](/docs/datatypes/money.html)). For example, to fetch the highest salary of all of the employees in the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=max(employee_annual_salary)" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=max(annual_salary)" %}
 
 It can also be used in `$group` aggregations, like this one to get the maximum salary by job type:
 

--- a/docs/functions/min.md
+++ b/docs/functions/min.md
@@ -33,7 +33,7 @@ parents:
 
 The `min(...)` function is most commonly used in `$select` aggregations to return the minimum of a set of numeric values ([Numbers](/docs/datatypes/number.html), [Doubles](/docs/datatypes/double.html), or [Moneys](/docs/datatypes/money.html)). For example, to fetch the lowest salary of all of the employees in the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=min(employee_annual_salary)" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=min(annual_salary)" %}
 
 It can also be used in `$group` aggregations, like this one to get the minimum salary by job type:
 

--- a/docs/functions/not_between.md
+++ b/docs/functions/not_between.md
@@ -35,7 +35,7 @@ parents:
 
 `not between` is used with the `$where` parameter to return numeric or time stamp values excluding those between two input values. For example, to get all of the individuals who make less than $40,000 or more than $150,000 at the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$where=employee_annual_salary not between '40000' and '150000'" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$where=annual_salary not between '40000' and '150000'" %}
 
 It can also be used on [Floating Timestamps](/docs/datatypes/floating_timestamp.html). For example, to get all of the crimes that occurred outside noon and 2PM on January 10th, 2015 in Chicago:
 

--- a/docs/functions/stddev_pop.md
+++ b/docs/functions/stddev_pop.md
@@ -29,10 +29,10 @@ parents:
 
 The `stddev_pop(...)` function is most commonly used in `$select` aggregations to return the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of the population of a set of numeric values ([Numbers](/docs/datatypes/number.html), [Doubles](/docs/datatypes/double.html), or [Moneys](/docs/datatypes/money.html)). It is most often used to compare the distribution of values against the mean of those values. For example, to fetch the average and standard deviation of the salaries of all of the employees at the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=avg(employee_annual_salary),stddev_pop(employee_annual_salary)" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=avg(annual_salary),stddev_pop(annual_salary)" %}
 
 It can also be used in `$group` aggregations, like this one to get the average and standard deviation of White House salaries by job type:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=job_titles,avg(employee_annual_salary),stddev_pop(employee_annual_salary)&$group=job_titles" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=job_titles,avg(annual_salary),stddev_pop(annual_salary)&$group=job_titles" %}
 
 A similar function, [`stddev_samp(...)`](/docs/functions/stddev_samp.html) allows you to calculate the standard deviation based on a sampling of values.

--- a/docs/functions/stddev_samp.md
+++ b/docs/functions/stddev_samp.md
@@ -29,10 +29,10 @@ parents:
 
 The `stddev_samp(...)` function is most commonly used in `$select` aggregations to return the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of the a sample of a set of numeric values ([Numbers](/docs/datatypes/number.html), [Doubles](/docs/datatypes/double.html), or [Moneys](/docs/datatypes/money.html)). It is most often used to compare the distribution of values against the mean of those values. For example, to fetch the average and standard deviation of the salaries of all of the employees at the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=avg(employee_annual_salary),stddev_samp(employee_annual_salary)" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=avg(annual_salary),stddev_samp(annual_salary)" %}
 
 It can also be used in `$group` aggregations, like this one to get the average and standard deviation of salaries by job type:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=job_titles,avg(employee_annual_salary),stddev_samp(employee_annual_salary)&$group=job_titles" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=job_titles,avg(annual_salary),stddev_samp(annual_salary)&$group=job_titles" %}
 
 A similar function, [`stddev_pop(...)`](/docs/functions/stddev_pop.html) allows you to calculate the standard deviation based on the entire population of values.

--- a/docs/functions/sum.md
+++ b/docs/functions/sum.md
@@ -29,8 +29,8 @@ parents:
 
 The `sum(...)` function is most commonly used in `$select` aggregations to return the sum of a set of numeric values ([Numbers](/docs/datatypes/number.html), [Doubles](/docs/datatypes/double.html), or [Moneys](/docs/datatypes/money.html)). For example, to fetch the total amount spent on salaries in the City of Chicago:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=sum(employee_annual_salary)" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=sum(annual_salary)" %}
 
 It can also be used in `$group` aggregations, like this one to get the sum of salaries by job type:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=job_titles,sum(employee_annual_salary)&$group=job_titles" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=job_titles,sum(annual_salary)&$group=job_titles" %}

--- a/docs/functions/upper.md
+++ b/docs/functions/upper.md
@@ -25,7 +25,7 @@ parents:
 
 The `upper(...)` function is used within the `$select` or `$where` parameters to upper-case a [Text](/docs/datatypes/text.html) value. For example, you could use it within the `$select` statement to upper-case names from the Chicago salaries dataset:
 
-{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=upper(name), employee_annual_salary" %}
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/tt4n-kn4t.json' args="$select=upper(name), annual_salary" %}
 
 You can also use it within the `$where` parameter to do case-insensitive matches:
 


### PR DESCRIPTION
City of Chicago updated the formatting and column names
for the Current Employee Names, Salaries, and Position Titles
data set (xzkq-xp2w). Namely, renamed the annual salary column, which
broke a number of examples.

For this fix, I've done a "find" within the functions/ folder and
updated examples referncing the "employee_annual_salary" column and
renamed it to the correct name.

I have not looked for other examples at this point.