### PR TITLE
Including R in publisher API support

### DIFF
--- a/publishers/index.md
+++ b/publishers/index.md
@@ -58,6 +58,7 @@ To learn more about the Socrata Publisher API, see the [getting started guide](/
 [Libraries &amp; SDKs](/libraries/) that have Publisher API support include:
 
 - [DataSync SDK](http://socrata.github.io/datasync/guides/datasync-library-sdk.html) (recommended Java library)
+- [R](https://github.com/Chicago/RSocrata)
 - [Ruby](https://github.com/socrata/soda-ruby)
 - [PHP](http://github.com/socrata/soda-php)
 - [.NET](https://github.com/CityofSantaMonica/SODA.NET)


### PR DESCRIPTION
RSocrata contains the `write.socrata` function, which allows publishing data through R. It supports `PUT` and `POST` publishing.