### PR TITLE
fix reference to results variable

### DIFF
--- a/snippets/pandas.py
+++ b/snippets/pandas.py
@@ -33,4 +33,4 @@ client = Socrata("%%domain%%", None)
 results = client.get("%%uid%%", limit=2000)
 
 # Convert to pandas DataFrame
-results_df = pd.DataFrame.from_records(result_list)
+results_df = pd.DataFrame.from_records(results)


### PR DESCRIPTION
Fixes example that wouldn't run as-is, since the variable is named `results` but was being referenced as `results_list`.