### PR TITLE
Github author plugin: Don't add broken location and company links

### DIFF
--- a/js/github.js
+++ b/js/github.js
@@ -62,13 +62,17 @@ require(["jquery", "humane"], function($) {
       // Meta
       var meta = $(element).find("ul.meta");
       if(profile.company) {
-        meta.append('<li><a href="' + profile.company + '"><i class="fa fa-fw fa-building-o"></i> ' + profile.company + '</a></li>');
+        if (profile.company.includes(/http/)) {
+          meta.append('<li><a href="' + profile.company + '"><i class="fa fa-fw fa-building-o"></i> ' + profile.company + '</a></li>');
+        } else {
+          meta.append('<li><i class="fa fa-fw fa-building-o"></i> ' + profile.company + '</li>');
+        }
       }
       if(profile.blog) {
         meta.append('<li><a href="' + profile.blog + '"><i class="fa fa-fw fa-link"></i> ' + profile.blog + '</a></li>');
       }
       if(profile.location) {
-        meta.append('<li><a href="' + profile.location + '"><i class="fa fa-fw fa-globe"></i> ' + profile.location + '</a></li>');
+        meta.append('<li><i class="fa fa-fw fa-globe"></i> ' + profile.location + '</li>');
       }
 
     }).fail(function(jqxhr, text_status, error) {


### PR DESCRIPTION
## Background

We run a little bit of javascript to fetch post authors' profile from github and then fill in the details.

## Before this change

We created broken links for company and location, which are not guaranteed to be urls. See links in [this post](https://dev.socrata.com/blog/2017/08/28/elixir-in-production.html).

## After this change

We'll never link location (because it's pretty much never a url), and we'll only link company if it's a url.
