### PR TITLE
Clarify required order of parameters

### DIFF
--- a/docs/functions/between.md
+++ b/docs/functions/between.md
@@ -42,3 +42,9 @@ parents:
 It can also be used on [Floating Timestamps](/docs/datatypes/floating_timestamp.html). For example, to get all of the crimes that occurred between noon and 2PM on January 10th, 2015 in Chicago:
 
 {% include tryit.html domain='data.cityofchicago.org' path='/resource/6zsd-86xi.json' args="$where=date between '2015-01-10T12:00:00' and '2015-01-10T14:00:00'" %}
+
+The first input value must be smaller than the second input value. This applies to negative numbers as well. For example, to get all of the crimes that happened between longitudes of -87 and -88 in Chicago:
+
+{% include tryit.html domain='data.cityofchicago.org' path='/resource/6zsd-86xi.json' args="$where=longitude between '-88' and '-87'" %}
+
+Note that the opposite (`longtiude between '-87' and '-88'`) would return no results.


### PR DESCRIPTION
Parameters in a `between ... and ...` must be in least to greatest order. This was giving me an issue until I came across this SO thread: https://stackoverflow.com/questions/40364213/query-with-negative-numbers-not-working-as-expected. It's not exactly intuitive that it would work this way, and I think the documentation should reflect the behavior.