### PR TITLE
Exclude '?' if no args are present

### DIFF
--- a/_includes/tryit.html
+++ b/_includes/tryit.html
@@ -1,2 +1,6 @@
-{% capture full_url %}https://{{ include.domain }}{{ include.path }}?{{ include.args }}{% endcapture %}
+{% if include.args %}
+  {% capture full_url %}https://{{ include.domain }}{{ include.path }}?{{ include.args }}{% endcapture %}
+{% else %}
+  {% capture full_url %}https://{{ include.domain }}{{ include.path }}{% endcapture %}
+{% endif %}
 <a class="tryit" href="{{ full_url | uri_escape }}">{{ full_url | replace: "%", "%25" | replace: "'", "&#39;" | replace: "\"", "&quot;" }}</a>


### PR DESCRIPTION
We had been including a question mark at the end of tryit URLs regardless of whether there were query arguments present. This wasn't causing issues, AFAIK: it just looked weird when we rendered the URL with a question mark at the end of it. So let's exclude it if no query arguments are present.