### PR TITLE
#821: Use get instead of getByResourceName

### DIFF
--- a/js/foundry.js
+++ b/js/foundry.js
@@ -617,13 +617,9 @@ define(
     // For legacy API Foundry endpoints, they have customized resource names
     // Here we should fail if we can't find the dataset by resource name
     $.ajax({
-      url: query_base + "/api/views.json",
+      url: query_base + "/api/views/" + args.uid + ".json",
       method: "GET",
-      dataType: "json",
-      data: {
-        "method": "getByResourceName",
-        "name": args.uid
-      }
+      dataType: "json"
     }).success(function(viewMetadata) {
       if (!viewMetadata) {
         return false;


### PR DESCRIPTION
`getByResourceName` returns a view object that does not do special things related to the [OBE/NBE migration](https://support.socrata.com/hc/en-us/articles/360018865074-Technical-Update-Dataset-Storage-Upgrade). For example, it returns a "location" column as a "point" column plus four location "sub-columns", whereas `/views/4x4` returns it properly as a "location" column without the sub-columns (for backend-y migration reasons related to backwards compatibility).