### PR TITLE
Update links to get help on homepage and support page

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ custom_js:
 ---
 
 <div class="fat-header hidden-sm hidden-xs">
-  <a href="http://snuffleupadata.com" target="_blank"><img src="/img/snuffleupacan.png" alt="snuffleupadata" class="pull-left" /></a>
+  <a href="https://snuffleupadata.com" target="_blank"><img src="/img/snuffleupacan.png" alt="snuffleupadata" class="pull-left" /></a>
   <h1 class="hello-dolly"><noscript>puts "Hello Data!";</noscript></h1>
 </div>
 
@@ -83,17 +83,14 @@ custom_js:
       <p>We're here to help! Check out the resources below for answers.</p>
 
       <dl>
-        <dt><a href="https://stackoverflow.com/search?tab=newest&q=soda%20OR%20socrata"><i class="fa fa-fw fa-stack-overflow"></i> Stack Overflow</a><dt>
-          <dd>We follow the <code>soda</code> and <code>socrata</code> tags on Stack Overflow.</dd>
-
         <dt><a href="https://github.com/socrata"><i class="fa fa-fw fa-github"></i> GitHub</a><dt>
           <dd>Socrata <i class="fa fa-heart"></i>'s Open Source!</dd>
 
-        <dt><a href="https://github.com/socrata/discuss/issues"><i class="fa fa-fw fa-bug"></i> Issue Tracker</a><dt>
-          <dd>Raise and discuss issues with the Socrata API, datasets, or data itself</dd>
+        <dt><a href="https://support.socrata.com/anonymous_requests/new"><i class="fa fa-fw fa-envelope"></i> Socrata Support</a><dt>
+          <dd>Raise issues with the Socrata API</dd>
 
-        <dt><a href="/changelog/"><i class="fa fa-fw fa-code-fork"></i> Changelog</a></dt>
-        <dd>Track the latest updates to our APIs and learn about upcoming changes.</dd>
+        <dt><a href="https://support.socrata.com/hc/en-us/articles/202949748-How-do-I-contact-a-dataset-s-owner-"><i class="fa fa-fw fa-user"></i> Contact Data Owner</a><dt>
+          <dd>Reach out directly to the data owner for questions about the data itself</dd>
       </dl>
     </div>
 

--- a/support.html
+++ b/support.html
@@ -7,7 +7,7 @@ audience: all
 <div class="jumbotron">
   <h1>Help!!!</h1>
 
-  <p class="lead">So, it sounds like you&#8217;ve hit a snag and need a hand. Fortunately we have a number of options available for you to seek assistance, depending on what you&#8217;re looking to do. Find the closest match below and we&#8217;ll be there to help you out!</p>
+  <p class="lead">So, it sounds like you&#8217;ve hit a snag and need a hand. Fortunately we have an amazing Support Team that can assist you, depending on what you&#8217;re looking to do!</p>
 </div>
   
 
@@ -15,13 +15,13 @@ audience: all
   <div class="col-lg-6">
     <h3><i class="fa fa-fw fa-stack-overflow"><!-- TSLB --></i> If you&#8217;re an app developer...</h3>
 
-        <p>If you&#8217;ve got questions about how to access Socrata data programmatically, or even just a general questions about Socrata, you can <a href="http://stackoverflow.com/questions/ask?tags=soda,socrata">post them to Stack Overflow</a> using the <a href="http://stackoverflow.com/questions/tagged/soda"><code>soda</code></a> or <a href="http://stackoverflow.com/questions/tagged/socrata"><code>socrata</code></a> tags and we&#8217;ll help you out!</p>
+        <p>If you&#8217;ve got questions about how to access Socrata data programmatically, or even just a general question about Socrata, you can <a href="https://support.socrata.com/anonymous_requests/new">submit a support ticket</a> to our Support Team, and we&#8217;ll help you out!</p>
   </div>
 
   <div class="col-lg-6">
     <h3><i class="fa fa-fw fa-cloud-upload"><!-- TSLB --></i> If you&#8217;re a data publisher...</h3>
 
-    <p>If you&#8217;re a data publisher and you need help setting up data publishing, or if you have publisher-specific questions, you can also <a href="http://support.socrata.com/anonymous_requests/new">submit a trouble ticket</a> for our support team to have a look at. You can also reference our <a href="https://support.socrata.com/hc/en-us">online knowledge base</a> which is chock-full of helpful articles about many of the most frequently requested publisher topics.</p>
+    <p>If you&#8217;re a data publisher and you need help setting up data publishing, or if you have publisher-specific questions, you can also <a href="https://support.socrata.com/anonymous_requests/new">submit a support ticket</a> for our Support Team to have a look at. You can also reference our <a href="https://support.socrata.com/hc/en-us">online knowledge base</a>, which is chock-full of helpful articles about many of the most frequently requested publisher topics.</p>
   </div>
 </div>
 


### PR DESCRIPTION
Unfortunately, we're not actively managing some of these channels anymore. So instead of pointing our developer community somewhere where they're unlikely to get help, let's direct them to our Support Team!