### PR TITLE
Add link to SoQL operator docs from the SoQL functions docs

### DIFF
--- a/docs/functions/index.html
+++ b/docs/functions/index.html
@@ -8,4 +8,6 @@ custom_js:
 
 <p>The following are all the functions and keywords available in SoQL. Some only work on the <a href="/docs/endpoints.html">the latest version of our API endpoints</a>, while some work on legacy versions as well. You can filter them by endpoint version and datatype using the filters below.</p>
 
+<p>For a list of valid operators, see the <a href="/docs/datatypes">Datatypes</a> documentation.</p>
+
 {% include function_listing.html datatype="all" %}


### PR DESCRIPTION
Where do I find the `+`, `||`, etc??? Maybe it's on the SoQL functions list page!!

## Before

![Screen Shot 2021-06-17 at 12 45 21 PM](https://user-images.githubusercontent.com/2808020/122439766-c686fa00-cf50-11eb-864e-38e777d9f452.png)

I was wrong!! now !! what !! ????


## After

![Screen Shot 2021-06-17 at 12 43 33 PM](https://user-images.githubusercontent.com/2808020/122439760-c555cd00-cf50-11eb-9438-3626a01fe21f.png)

oh ty i will try the datatypes page