### PR TITLE
Add PowerShell SDK to libraries page

### DIFF
--- a/libraries/powershell.md
+++ b/libraries/powershell.md
@@ -1,0 +1,16 @@
+---
+layout: external-link
+title: PowerShell
+type: sdk
+audience: all
+
+language: PowerShell
+
+external_url: https://github.com/socrata/Socrata-PowerShell
+docs_url: https://github.com/socrata/Socrata-PowerShell
+
+github_user: socrata
+github_repo: Socrata-PowerShell
+
+official: true
+---

--- a/snippets/pandas.py
+++ b/snippets/pandas.py
@@ -25,7 +25,7 @@ client = Socrata("%%domain%%", None)
 # Example authenticated client (needed for non-public datasets):
 # client = Socrata(%%domain%%,
 #                  MyAppToken,
-#                  userame="user@example.com",
+#                  username="user@example.com",
 #                  password="AFakePassword")
 
 # First 2000 results, returned as JSON from API / converted to Python list of


### PR DESCRIPTION
This branch adds https://github.com/socrata/Socrata-PowerShell to the [Libraries & SDKs](https://dev.socrata.com/libraries/) page, and also fixes an unrelated typo in the pandas snippet.