### PR TITLE
EN-63635: Move the prefix from server url to path url in Metadata API docs

### DIFF
--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -7,11 +7,11 @@
     },
     "servers": [
         {
-            "url": "evergreen.data.socrata.com/api/views/"
+            "url": "evergreen.data.socrata.com"
         }
     ],
     "paths": {
-        "/metadata/v1?help": {
+        "/api/views/metadata/v1?help": {
             "get": {
                 "responses": {
                     "200": {
@@ -27,7 +27,7 @@
                 "parameters": []
             }
         },
-        "/metadata/v1": {
+        "/api/views/metadata/v1": {
             "get": {
                 "responses": {
                     "200": {
@@ -62,7 +62,7 @@
                 ]
             }
         },
-        "/metadata/v1/{uuid}": {
+        "/api/views/metadata/v1/{uuid}": {
             "get": {
                 "responses": {
                     "200": {
@@ -157,7 +157,7 @@
                 }
             }
         },
-        "/metadata/v1/{uuid} ": {
+        "/api/views/metadata/v1/{uuid} ": {
             "patch": {
                 "responses": {
                     "200": {


### PR DESCRIPTION
Before:
<img width="507" alt="Screen Shot 2024-01-23 at 2 55 07 PM" src="https://github.com/socrata/dev.socrata.com/assets/40923/88c3432b-c37b-4ef5-8167-303f84ab1ae9">

After:
<img width="453" alt="Screen Shot 2024-01-23 at 2 55 13 PM" src="https://github.com/socrata/dev.socrata.com/assets/40923/1839ce05-c0b4-44b1-b62e-d621ab6bec64">
