### PR TITLE
EN-64629: Shadow /* to 200.html for Netlify.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/200.html"
+status = 200


### PR DESCRIPTION
Surge.sh docs: https://surge.sh/help/adding-a-200-page-for-client-side-routing
Netlify docs: https://docs.netlify.com/routing/redirects/rewrites-proxies/#shadowing

"Shadowing" appears to be the correct behavior desired. Real pages that otherwise exist seem to automatically not get redirected by this rule, so that's neat.

Resolves #930