### PR TITLE
EN-64647: restrict shadowing to foundry urls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
-from = "/*"
+from = "/foundry/*"
 to = "/200.html"
 status = 200


### PR DESCRIPTION
- More switching-to-Netlify fallout.
- 200.html doesn't support anything besides Foundry anyways.
- Should probably rename 200.html, but that's a future-me problem.
- This fixes /docs/queries/ going on an infinite-redirect loop.