### PR TITLE
EN-64647: Remove redundant redirect_from directives

### DIFF
--- a/_data/legacy-blog.xml
+++ b/_data/legacy-blog.xml
@@ -1139,7 +1139,7 @@ Socrata, Inc.</p>
 <p>The <a href="http://labs.socrata.com/docs/search.html">Catalog Search API</a> - The catalog search API allows you to query the entire Socrata open data catalog, across all of the public datasets hosted on all of our customers public data portals. In addition, we're applying machine learning techniques to improve how datasets are categorized and to allow for consistent categories across data catalogs.</p>
 </li>
 	<li>
-<p>Our new <a href="http://labs.socrata.com/docs/export.html">Export API</a> - Beyond providing much faster, cached export functionality, the new export service also allows you to filter exports using<a href="http://dev.socrata.com/docs/queries.html">SoQL queries</a> to retrieve only the data you were looking for.</p>
+  <p>Our new <a href="http://labs.socrata.com/docs/export.html">Export API</a> - Beyond providing much faster, cached export functionality, the new export service also allows you to filter exports using<a href="http://dev.socrata.com/docs/queries/index.html">SoQL queries</a> to retrieve only the data you were looking for.</p>
 </li>
 </ul>
 <p>As these are prerelease APIs, they may change to reflect feedback from the community, but we wanted to get them in front of all of you as early as possible to see what you'll be able to build with them!</p>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -1,8 +1,6 @@
 ---
 layout: default
 title: Changelog
-redirect_from:
-- /changelog.html
 custom_css:
 - //cdnjs.cloudflare.com/ajax/libs/octicons/2.0.2/octicons.min.css
 - /common/css/github-activity.css

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -13,7 +13,7 @@ All resources are accessed through a common base path of `/resource/` along with
 
 {% include tryit.html domain='data.cityofchicago.org' path='/resource/ydr8-5enu.json' %}
 
-Once you've got your API endpoint, you can add on [filtering](/docs/filtering.html) and [SoQL](/docs/queries.html) parameters to filter and manipulate your dataset.
+Once you've got your API endpoint, you can add on [filtering](/docs/filtering.html) and [SoQL](/docs/queries/index.html) parameters to filter and manipulate your dataset.
 
 ## Locating the API endpoint for a dataset
 

--- a/docs/queries/index.md
+++ b/docs/queries/index.md
@@ -3,7 +3,6 @@ layout: with-sidebar
 sidebar: documentation
 title: Queries using SODA
 redirect_from:
-  - /docs/queries.html
   - /docs/aggregation.html
   - /deprecated/querying-datasets
 ---

--- a/foundry/branding.mst
+++ b/foundry/branding.mst
@@ -4,7 +4,7 @@
   {{/logo_href}}
   <h4 class="welcome">Welcome to this <a href="{{ org_homepage }}" target="_blank">{{ org_name }}</a> API, powered by <a href="http://dev.socrata.com/">Socrata</a></h4>
 
-  <p class="more-info">For more information on how to access this asset via the <a href="/">Socrata Open Data API</a>, read on. Additional information on <a href="/docs/queries.html">query functionality</a>, <a href="/consumers/examples/">code samples</a>, and <a href="/libraries">libraries</a> can be accessed using the navigation above.</p>
+  <p class="more-info">For more information on how to access this asset via the <a href="/">Socrata Open Data API</a>, read on. Additional information on <a href="/docs/queries/index.html">query functionality</a>, <a href="/consumers/examples/">code samples</a>, and <a href="/libraries">libraries</a> can be accessed using the navigation above.</p>
 
   <hr />
 </div>

--- a/foundry/queries.mst
+++ b/foundry/queries.mst
@@ -10,7 +10,7 @@
 
 <h4>Query Options</h4>
 
-<p>You can also use <a href="/docs/queries.html">SoQL queries</a> with this column. Since it is a <code>{{datatype}}</code> column, <a href="/docs/datatypes/{{datatype}}.html">many different query functions</a> are available.</p>
+<p>You can also use <a href="/docs/queries/index.html">SoQL queries</a> with this column. Since it is a <code>{{datatype}}</code> column, <a href="/docs/datatypes/{{datatype}}.html">many different query functions</a> are available.</p>
 
 {{#suggestions.query}}
   <p>For example:</p>


### PR DESCRIPTION
Jekyll generates a "Redirecting" html file for these, and two of them are causing infinite redirect loops due to a poor interaction with Netlify's "Pretty URL" mechanism.

https://docs.netlify.com/site-deploys/post-processing/#post-processing-features
> Netlify rewrites /about to /about/ or /about.html to /about/.

These are the two problem cases I found. It's possible I missed one, since this finding came from manually inspecting stuff.